### PR TITLE
Fix typos and expand repo description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 - 👋 Hi, I’m Vincent Goldschmidt
-- 👀 I’m interested in AI, modeling, medical imaging, biomarkers, LLM, quantum physics etc.
+- 👀 I’m interested in AI, modeling, medical imaging, biomarkers, LLM, quantum physics, etc.
 - 🌱 I’m currently in the first year of my PhD thesis at Paris Saclay University. I'm an MD in medical oncology
 - 📫 How to reach me : on my profile or by email : vincent.goldschmidt@etu-upsclay.fr
 
 ## Repository overview
 
-This repository contains a simple workflow diagram created with draw.io. The file `Diagramme sans nom.drawio` outlines how I manage research documents by checking whether each file has been processed and determining the next action. I use this diagram as part of my exploration of AI and large language models for automating medical imaging and biomarker analysis workflows. As my PhD work evolves, the diagram will serve as a starting point for more detailed models and projects.
+This repository contains a simple workflow diagram created with draw.io. The file [`Diagramme sans nom.drawio`](./Diagramme%20sans%20nom.drawio) outlines how I manage research documents by checking whether each file has been processed and determining the next action. I use this diagram as part of my exploration of AI and large language models for automating medical imaging and biomarker analysis workflows. As my PhD work evolves, the diagram will serve as a starting point for more detailed models and projects.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 - 👋 Hi, I’m Vincent Goldschmidt
-- 👀 I’m interested in AI, modeling, medical imagerie, biomarkers, LLM, quantic physics etc.
-- 🌱 I’m currently on first year PHD thesis at Paris Saclay University , i'm MD in medical oncology
+- 👀 I’m interested in AI, modeling, medical imaging, biomarkers, LLM, quantum physics etc.
+- 🌱 I’m currently in the first year of my PhD thesis at Paris Saclay University. I'm an MD in medical oncology
 - 📫 How to reach me : on my profile or by email : vincent.goldschmidt@etu-upsclay.fr
+
+## Repository overview
+
+This repository contains a simple workflow diagram created with draw.io. The file `Diagramme sans nom.drawio` outlines how I manage research documents by checking whether each file has been processed and determining the next action. I use this diagram as part of my exploration of AI and large language models for automating medical imaging and biomarker analysis workflows. As my PhD work evolves, the diagram will serve as a starting point for more detailed models and projects.


### PR DESCRIPTION
## Summary
- fix typos in README (`imagerie` -> `imaging`, `quantic` -> `quantum`)
- clarify the research description and explain how the diagram fits the work

## Testing
- `git status --short`